### PR TITLE
Fix navigation bar overlay issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -949,6 +949,16 @@ window.ShopifyPay.apiHost = "shop.app\/pay";</script>
   data-resource-timing-sampling-rate="10"
   data-shs="true"
 ></script>
+<style>
+  header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+  }
+  #page-transition-overlay {
+    z-index: 0 !important;
+  }
+</style>
 </head>
 
   <body class="template-index">


### PR DESCRIPTION
## Summary
- keep the header visible by making it sticky and raising its z-index
- ensure the page transition overlay sits behind the navbar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a482e58c832997f06fbd0a95b3ef