### PR TITLE
Adjust header logo size and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,6 +549,26 @@ clamp(0.67224375rem, 0.6575830110497237rem + 0.06255248618784531vw, 0.707625rem)
     
 
 </style>
+<style>
+  /* Custom adjustments for larger centered logo and spaced navigation */
+  .header__row.logo-only {
+    display: flex !important;
+    justify-content: center !important;
+    background: #000 !important;
+  }
+
+  .header__logo {
+    position: relative !important;
+    left: auto !important;
+    transform: scale(2) !important;
+    transform-origin: center !important;
+    margin: 40px 0 !important;
+  }
+
+  .header__row.lower {
+    margin-top: 40px !important;
+  }
+</style>
 
 <script>
   flu = window.flu || {};


### PR DESCRIPTION
## Summary
- enlarge main logo and center in header
- add breathing room around logo
- give nav bar extra space toward bottom

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881aec41cfc832997584e386cc30263