### PR TITLE
Increase main logo size and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,9 +560,9 @@ clamp(0.67224375rem, 0.6575830110497237rem + 0.06255248618784531vw, 0.707625rem)
   .header__logo {
     position: relative !important;
     left: auto !important;
-    transform: scale(2) !important;
-    transform-origin: center !important;
-    margin: 40px 0 !important;
+    transform: none !important;
+    margin-top: 60px !important;
+    text-align: center !important;
   }
 
   .header__row.lower {
@@ -1232,7 +1232,7 @@ window.ShopifyPay.apiHost = "shop.app\/pay";</script>
     </nav>
       </div>
     </div><div class="header__row header__row-desktop logo-only" style="position: relative !important;">
-        <h1 class="header__logo" style="position: absolute !important; left: 50% !important; transform: translateX(-50%) !important; width: auto !important; margin: 0 !important; z-index: 999 !important;">
+        <h1 class="header__logo">
     <a
       class="header__logo-link"
       href="index.html"
@@ -1458,7 +1458,7 @@ window.ShopifyPay.apiHost = "shop.app\/pay";</script>
   </button>
         </div>
 
-        <h1 class="header__logo" style="position: absolute !important; left: 50% !important; transform: translateX(-50%) !important; width: auto !important; margin: 0 !important; z-index: 999 !important;">
+        <h1 class="header__logo">
     <a
       class="header__logo-link"
       href="index.html"
@@ -3724,7 +3724,7 @@ _ReStockConfig.wishlist = undefined;_ReStockConfig.wishlist = {"is_service_activ
         // Fix duplicate IDs by making them unique
         canvas.id = `fuzzy-text-canvas-${index + 1}`;
         createFuzzyText(canvas.id, 'NODRAMA RECORDS', {
-          fontSize: '2.5rem',
+          fontSize: '5rem',
           fontWeight: 900,
           fontFamily: 'Arial, sans-serif',
           color: '#ffffff',
@@ -3742,7 +3742,7 @@ _ReStockConfig.wishlist = undefined;_ReStockConfig.wishlist = {"is_service_activ
         // Fix duplicate IDs by making them unique
         canvas.id = `fuzzy-text-location-${index + 1}`;
         createFuzzyText(canvas.id, 'San Francisco, CA', {
-          fontSize: '1.2rem',
+          fontSize: '2.4rem',
           fontWeight: 600,
           fontFamily: 'Arial, sans-serif',
           color: '#ffffff',


### PR DESCRIPTION
## Summary
- enlarge hero logo canvas fonts
- remove absolute positioning on logo
- adjust custom styles for larger centered logo

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b02eb4f88329bd709f1c76e5a1b0