### PR TITLE
Fix header clipping and improve announcement spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,6 +568,17 @@ clamp(0.67224375rem, 0.6575830110497237rem + 0.06255248618784531vw, 0.707625rem)
   .header__row.lower {
     margin-top: 40px !important;
   }
+
+  /* Ensure logo text isn't clipped */
+  .regular-logo {
+    overflow: visible !important;
+  }
+
+  /* Give announcement text breathing room */
+  .announcement-bar {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
 </style>
 
 <script>


### PR DESCRIPTION
## Summary
- prevent clipping of `NODRAMA RECORDS` canvas by letting the logo container overflow visibly
- add vertical spacing around the announcement bar to keep it from looking cramped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881b1aa77648329abbaa7b7f6971483