### PR TITLE
Fix header logo clipping issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -572,6 +572,8 @@ clamp(0.67224375rem, 0.6575830110497237rem + 0.06255248618784531vw, 0.707625rem)
   /* Ensure logo text isn't clipped */
   .regular-logo {
     overflow: visible !important;
+    line-height: 1.2 !important;
+    padding-bottom: 20px !important;
   }
 
   /* Give announcement text breathing room */


### PR DESCRIPTION
## Summary
- ensure the logo container allows enough space

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881b33fd2888329a01a8e07adce2360